### PR TITLE
Webpack4 experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,25 @@ $ wc -c dist/*
 # Do custom minification that's actually readable while still doing DCE
 # so you can inspect `dist.main.js` to look for tree shaking (`unused` comments).
 $ DEMO=true yarn run build
-$ $ wc -c dist/*
+$ wc -c dist/*
  1050848 dist/one-off-import.js
  1597913 dist/use-index.js
+```
+
+Here's current for `webpack@4`:
+
+```sh
+# Just build
+$ yarn run build
+$ wc -c dist/*
+  212245 dist/one-off-import.js
+  212289 dist/use-index.js
+
+# Demo version.
+$ DEMO=true yarn run build
+$ wc -c dist/*
+  796586 dist/one-off-import.js
+  796837 dist/use-index.js
 ```
 
 ## Analysis - One Off vs. Using Index

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "devDependencies": {
     "lodash-webpack-plugin": "^0.11.4",
-    "webpack": "^3.10.0"
+    "uglifyjs-webpack-plugin": "^1.1.8",
+    "webpack": "^4.0.0-beta.0",
+    "webpack-cli": "^2.0.4"
   },
   "scripts": {
     "build": "webpack"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 var path = require("path");
 var webpack = require("webpack");
 var LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
+var UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 var IS_DEMO = process.env.DEMO === "true";
 
@@ -16,6 +17,7 @@ var ENTRY_POINTS = [
 ];
 
 module.exports = ENTRY_POINTS.map((name) => ({
+  mode: IS_DEMO ? "development" : "production",
   context: path.resolve("src"),
   entry: {
     [name]: "./" + name + ".js"
@@ -24,6 +26,10 @@ module.exports = ENTRY_POINTS.map((name) => ({
     path: path.resolve("dist"),
     filename: "[name].js",
     pathinfo: true
+  },
+  devtool: false,
+  optimization: {
+    sideEffects: true
   },
   plugins: [
     new webpack.DefinePlugin({
@@ -42,12 +48,14 @@ module.exports = ENTRY_POINTS.map((name) => ({
       minimize: true,
       debug: false
     }),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: true,
-      mangle: !IS_DEMO,       // DEMO ONLY: Don't change variable names.
-      beautify: IS_DEMO,      // DEMO ONLY: Preserve whitespace
-      output: {
-        comments: IS_DEMO     // DEMO ONLY: Helpful comments
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        compress: true,
+        mangle: !IS_DEMO,       // DEMO ONLY: Don't change variable names.
+        beautify: IS_DEMO,      // DEMO ONLY: Preserve whitespace
+        output: {
+          comments: IS_DEMO     // DEMO ONLY: Helpful comments
+        }
       },
       sourceMap: false
     })


### PR DESCRIPTION
@thelarkinn -- here's a "hello world" Victory app:

```js
import React from "react";
import { VictoryLine } from "victory";

export default render = function () {
  return React.createElement(VictoryLine, {
    data: [
      {month: "September", profit: 35000, loss: 2000},
      {month: "October", profit: 42000, loss: 8000},
      {month: "November", profit: 55000, loss: 5000}
    ],
    x: "month",
    y: function (datum) { return datum.profit - datum.loss }
  });
};
```

With `webpack@3` (currently in `master`) we end up with a production build that has:

- Root import (this example): `460 KB` because uglify isn't DCE'ing due to side effects.
- One-off import (approximating what should happen): `460 KB`

This branch upgrades to `webpack@4` with a production build that has:

- Root import (this example): `212 KB`
- One-off import: Also `212 KB` which means that tree shaking is not doing nearly exactly what a one-off import would do

Other important notes:

- All victory packages as of today have `package.main:sideEffects: false`.
- This is *all* pretty much reductions in unnecessary Victory code coming in...
- We have dependencies of React, Lodash, etc. and are still seeing this really sizeable reduction. If those were external'ed, the percentage drop would be even larger.

/cc @boygirl 